### PR TITLE
Add blob to CSP

### DIFF
--- a/biodatacatalyst-ui/httpd-vhosts-dev.conf
+++ b/biodatacatalyst-ui/httpd-vhosts-dev.conf
@@ -56,7 +56,7 @@ ServerTokens Prod
     # unsafe-inline - Allows inline JavaScript, CSS, and event handlers
     # style-src - Allows inline styles but only from the same origin
     # img-src - Allows images from the same origin and data: URIs
-    Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data: https://public.era.nih.gov;"
+    Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data: https://public.era.nih.gov blob:;"
 
     # A fall back for legacy browsers that don't yet support CSP frame-ancestors.
     Header always set X-Frame-Options "DENY"

--- a/biodatacatalyst-ui/httpd-vhosts.conf
+++ b/biodatacatalyst-ui/httpd-vhosts.conf
@@ -65,7 +65,7 @@ ServerTokens Prod
     # unsafe-inline - Allows inline JavaScript, CSS, and event handlers
     # style-src - Allows inline styles but only from the same origin
     # img-src - Allows images from the same origin and data: URIs
-    Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data: https://public.era.nih.gov;"
+    Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data: https://public.era.nih.gov blob:;"
 
     # A fall back for legacy browsers that don't yet support CSP frame-ancestors.
     Header always set X-Frame-Options "DENY"


### PR DESCRIPTION
We require the addition of "blob" to the image content security policy, allowing us to download the statistical visualization image of graphs.