### PR TITLE
[ALS-4797] add google analytics to core UI

### DIFF
--- a/biodatacatalyst-ui/httpd-vhosts-dev.conf
+++ b/biodatacatalyst-ui/httpd-vhosts-dev.conf
@@ -56,7 +56,7 @@ ServerTokens Prod
     # unsafe-inline - Allows inline JavaScript, CSS, and event handlers
     # style-src - Allows inline styles but only from the same origin
     # img-src - Allows images from the same origin and data: URIs
-    Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data: https://public.era.nih.gov blob:;"
+    Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com; img-src 'self' data: https://public.era.nih.gov blob:;"
 
     # A fall back for legacy browsers that don't yet support CSP frame-ancestors.
     Header always set X-Frame-Options "DENY"

--- a/biodatacatalyst-ui/httpd-vhosts.conf
+++ b/biodatacatalyst-ui/httpd-vhosts.conf
@@ -65,7 +65,7 @@ ServerTokens Prod
     # unsafe-inline - Allows inline JavaScript, CSS, and event handlers
     # style-src - Allows inline styles but only from the same origin
     # img-src - Allows images from the same origin and data: URIs
-    Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data: https://public.era.nih.gov blob:;"
+    Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com; img-src 'self' data: https://public.era.nih.gov blob:;"
 
     # A fall back for legacy browsers that don't yet support CSP frame-ancestors.
     Header always set X-Frame-Options "DENY"

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/common/mainLayout.hbs
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/common/mainLayout.hbs
@@ -1,15 +1,3 @@
-{{#if analyticsId}}
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{analyticsId}}"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', '{{analyticsId}}');
-    </script>
-{{/if}}
-
 <div id="query-builder" class="flex-container space-between">
     <div id="filter-list"></div>
     <div data-intro="#results-panel-auth" data-sequence="7" class="output-size panel results-panel">    


### PR DESCRIPTION
[ALS-4797] add google analytics to core UI. Can now be set via Jenkins global environment variable named `analytics_id`.