### PR TITLE
Fix API token render

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/picsureui/api-interface/apiPanelView.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/api-interface/apiPanelView.js
@@ -36,9 +36,9 @@ define([
             },
             render: function () {
                 userFunctions.meWithToken(this, (user) => {
-                    const userToken = new userToken(user);
-                    $('#user-profile').html(userToken.$el);
-                    userToken.render();
+                    const token = new userToken(user);
+                    $('#user-profile').html(token.$el);
+                    token.render();
                 });
 
                 this.displayDatasetManagementBox();


### PR DESCRIPTION
Variable name was reused, causing the component to fail to render.