### PR TITLE
[ALS-5534] Render template earlier in landing.js

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/picsureui/landing/landing.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/landing/landing.js
@@ -34,6 +34,8 @@ define(["underscore", "jquery", "backbone", "handlebars", "text!landing/landing.
                 window.location.href = "/picsureui/queryBuilder";
             },
             render: function () {
+                this.$el.html(this.template());
+
                 // get counts for studies and participants
                 let records = studyUtility.groupRecordsByAccess();
 
@@ -97,7 +99,6 @@ define(["underscore", "jquery", "backbone", "handlebars", "text!landing/landing.
                 spinner.medium(deferredParticipants, "#authorized-participants-spinner", "spinner2");
                 spinner.medium(deferredParticipants, "#authorized-studies-spinner", "spinner2");
 
-                this.$el.html(this.template());
                 return this;
             }
         });


### PR DESCRIPTION
[ALS-5534]  The order of operations has been altered in the landing.js file of the BioDataCatalyst UI. The current changes involve rendering the template right after the function is invoked rather than waiting until the end. This reordering will allow the loading icons to display until all ajax request are complete.