### PR TITLE
[ALS-5703] AIM-AHEAD PIC-SURE Help Tab

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/picsureui/common/pic-dropdown.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/common/pic-dropdown.js
@@ -44,19 +44,39 @@ define(["jquery", "common/keyboard-nav", "underscore"],function($, keyboardNav, 
     let toggleDropdown = (e) => {
         console.debug("toggleDropdown", e.target);
         const tab = e.target.closest('.header-btn');
-        const dropdown = tab.parentElement.querySelector(NAV_DROPDOWN_MENU_CLASS);
+        const dropdown = tab.nextElementSibling;
         toggleArrow(tab);
-        if (dropdown.classList.contains(OPEN)) {
-            dropdown.classList.remove(OPEN);
-            dropdown.setAttribute('aria-expanded', false);
+        if (dropdown.classList.contains('OPEN')) {
+            dropdown.classList.remove('OPEN');
+            dropdown.setAttribute('aria-expanded', 'false');
         } else {
-            dropdown.classList.add(OPEN);
-            dropdown.setAttribute('aria-expanded', true);
+            dropdown.classList.add('OPEN');
+            dropdown.setAttribute('aria-expanded', 'true');
+
+            // Calculate and adjust the dropdown position to avoid going off-screen
+            const dropdownOffset = $(tab).parent().offset().top + $(tab).parent().outerHeight();
+            const dropdownLeft = $(tab).offset().left;
             $(dropdown).offset({
-                top: $(tab).parent().offset().top + $(tab).parent().outerHeight(), 
-                left: $(tab).offset().left
+                top: dropdownOffset,
+                left: dropdownLeft
             });
-            getView().el.querySelector('#header-tabs').focus();
+
+            // Get viewport width
+            const viewportWidth = $(window).width();
+            // Calculate the right edge of the dropdown
+            const dropdownRightEdge = dropdownLeft + $(dropdown).outerWidth();
+
+            // Check if the dropdown goes off the right edge of the screen
+            if (dropdownRightEdge > viewportWidth) {
+                // Calculate the new left position to align the dropdown's right edge with the viewport's right edge
+                const newLeft = viewportWidth - $(dropdown).outerWidth();
+                $(dropdown).offset({
+                    top: dropdownOffset,
+                    left: newLeft
+                });
+            }
+
+            getView().el.querySelector('#header-tab').focus();
         }
     }
 

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/common/pic-dropdown.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/common/pic-dropdown.js
@@ -1,4 +1,4 @@
-define(["jquery", "common/keyboard-nav", "underscore"],function($, keyboardNav, _){
+define(["jquery", "common/keyboard-nav", "underscore"], function ($, keyboardNav, _) {
     let view = undefined;
 
     const OPEN = 'open';
@@ -30,7 +30,7 @@ define(["jquery", "common/keyboard-nav", "underscore"],function($, keyboardNav, 
         if (selectedTab && !currentView) {
             let viewName = selectedTab.parentElement.id;
             const dashLoc = viewName.indexOf('-');
-            viewName = viewName.substring(0,dashLoc) + viewName.charAt(dashLoc+1).toUpperCase() + viewName.substring(dashLoc+2);
+            viewName = viewName.substring(0, dashLoc) + viewName.charAt(dashLoc + 1).toUpperCase() + viewName.substring(dashLoc + 2);
             keyboardNav.setCurrentView(viewName);
         }
         selectedTab.classList.add('selected');
@@ -76,7 +76,7 @@ define(["jquery", "common/keyboard-nav", "underscore"],function($, keyboardNav, 
                 });
             }
 
-            getView().el.querySelector('#header-tab').focus();
+            tab.focus();
         }
     }
 
@@ -89,7 +89,7 @@ define(["jquery", "common/keyboard-nav", "underscore"],function($, keyboardNav, 
             const icon = dropdown.parentNode.querySelector('i.fa');
             if (icon) {
                 icon.classList.remove('fa-caret-up');
-                icon.classList.add('fa-caret-down');			
+                icon.classList.add('fa-caret-down');
             }
             dropdown.classList.remove(OPEN);
             dropdown.setAttribute('aria-expanded', false);


### PR DESCRIPTION
No longer toggles the wrong dropdown menu if two menus are present in the header. Now calculates if the dropdown menu would go beyond the viewport's width. If it does, it recalculates the left property to align the dropdown to the right edge of the screen. Lastly, the dropdown is now focused appropriately.