### PR TITLE
[ALS-6058] Refactor search term selection in search view

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/picsureui/openPicsure/studiesModal.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/openPicsure/studiesModal.js
@@ -137,17 +137,16 @@ define([
                 "columns": [
                     {title: "Abbreviation", data: "display_name"},
                     {title: "Accession", data: "identifier"},
-                    {title: "Counts", data: "study_matches"},
                     {title: "Counts by Consent Code", data: "consents"},
                     {title: "Access", data: null}
                 ],
                 "columnDefs": [
                     {
-                        targets: [0, 1, 2, 4],
+                        targets: [0, 1, 3],
                         className: "dt-center"
                     },
                     {
-                        targets: 4,
+                        targets: 3,
                         type: 'string',
                         render: function (data, type, row, meta) {
                             // Data is always null. Row is the entire row object.
@@ -159,7 +158,7 @@ define([
                         }
                     },
                     {
-                        targets: 3,
+                        targets: 2,
                         type: 'string',
                         render: function (data, type, row, meta) {
                             // data is a list of consents.

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/router.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/overrides/router.js
@@ -101,7 +101,8 @@ define(["backbone", "handlebars", "studyAccess/studyAccess", "picSure/settings",
                     const searchView = new SearchView({
                         queryTemplate: JSON.parse(parsedSess.queryTemplate),
 						queryScopes: parsedSess.queryScopes,
-                        el : $('#filter-list')
+                        el : $('#filter-list'),
+                        tourSearchTerm: "cardiac surgery"
                     });
 
                     $('#studies-list-panel').remove();

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-view.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-view.js
@@ -43,6 +43,9 @@ define(["jquery", "backbone", "handlebars", "underscore", "search-interface/tag-
                 //only include each tag once
                 this.antiScopeTags = searchUtil.getAntiScopeTags();
 
+                // Tour search term, use epilepsy by default because it is available in both open and authorized access
+                this.searchTerm = opts.tourSearchTerm ?? "epilepsy";
+
                 this.render();
                 this.subviews();
 
@@ -126,19 +129,11 @@ define(["jquery", "backbone", "handlebars", "underscore", "search-interface/tag-
                 return new Promise((resolve, reject) => {
                     try {
                         let results = $.Deferred();
-                        if (this.isOpenAccess) {
-                            $('#search-box').val('epilepsy');
-                            results = this.submitSearch($('#search-button').get());
-                            $.when(results).then(() => {
-                                resolve();
-                            });
-                        } else {
-                            $("#search-box").val("cardiac surgery");
-                            results = this.submitSearch($('#search-button').get());
-                            $.when(results).then(() => {
-                                resolve();
-                            });
-                        }
+                        $("#search-box").val(this.tourSearchTerm);
+                        results = this.submitSearch($('#search-button').get());
+                        $.when(results).then(() => {
+                            resolve();
+                        });
                     } catch (e) {
                         console.error(e);
                         reject(e);

--- a/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-view.js
+++ b/biodatacatalyst-ui/src/main/webapp/picsureui/search-interface/search-view.js
@@ -46,7 +46,7 @@ define(["jquery", "backbone", "handlebars", "underscore", "search-interface/tag-
                 this.antiScopeTags = searchUtil.getAntiScopeTags();
 
                 // Tour search term, use epilepsy by default because it is available in both open and authorized access
-                this.searchTerm = opts.tourSearchTerm ?? "epilepsy";
+                this.tourSearchTerm = opts.tourSearchTerm ?? "epilepsy";
 
                 this.render();
                 this.subviews();


### PR DESCRIPTION
The code has been refactored to unify the selection process of search terms in search view. Regardless of open or authorized access, the search term used will now be determined by the `tourSearchTerm` option provided. Default term for open access is "epilepsy" while for authorized access it can vary, for instance, "cardiac surgery" in biodatacatalyst and "race" in aim-ahead.