### PR TITLE
[ALS-6103] Changed URL for Ajax request in fenceLogin.js

### DIFF
--- a/biodatacatalyst-ui/src/main/webapp/psamaui/overrides/fenceLogin.js
+++ b/biodatacatalyst-ui/src/main/webapp/psamaui/overrides/fenceLogin.js
@@ -12,7 +12,7 @@ define(['picSure/settings', 'jquery', 'handlebars', 'text!login/fence_login.hbs'
                     $('#main-content').html("BioDataCatalyst authentication is successful. Processing UserProfile information...");
 
                     $.ajax({
-                        url: '/psama/authentication',
+                        url: '/psama/authentication/fence',
                         type: 'post',
                         data: JSON.stringify({
                             code: code


### PR DESCRIPTION
The URL for the Ajax request in the fenceLogin.js file has been updated. It has been changed from '/psama/authentication' to '/psama/authentication/fence'.